### PR TITLE
Update `new` command

### DIFF
--- a/packages/core/src/command_handlers/new.ts
+++ b/packages/core/src/command_handlers/new.ts
@@ -2,8 +2,24 @@ import * as p from "@clack/prompts";
 import { openInBrowser } from "../lib/utils/open";
 import { PM, detect } from "detect-package-manager";
 import { execa } from "execa";
+
+const startSupported = [
+  "bare",
+  "hackernews",
+  "todomvc",
+  "with-auth",
+  "with-authjs",
+  "with-mdx",
+  "with-prisma",
+  "with-solid-styled",
+  "with-tailwindcss",
+  "with-trpc",
+  "with-vitest",
+  "with-websocket",
+] as const;
 const localSupported = ["ts", "js"] as const;
 const stackblitzSupported = ["bare"] as const;
+
 type AllSupported = (typeof localSupported)[number] | (typeof stackblitzSupported)[number];
 const getRunner = (pM: PM) => {
   switch (pM) {
@@ -15,30 +31,80 @@ const getRunner = (pM: PM) => {
       return "pnpx";
   }
 };
+
+const handleNewStartProject = async (projectName: string) => {
+  const template = await p.select({
+    message: "Which template would you like to use?",
+    initialValue: "ts",
+    options: startSupported.map((s) => ({ label: s, value: s })),
+  });
+
+  if (p.isCancel(template)) {
+    p.log.warn("Canceled");
+    return;
+  }
+
+  const pM = await detect();
+  const s = p.spinner();
+  s.start("Creating project");
+
+  await execa(
+    getRunner(pM),
+    ["degit", `solidjs/solid-start/examples/${template}#main`, projectName].filter((e) => e !== null) as string[],
+  );
+
+  s.stop("Project successfully created! 🎉");
+
+  p.log.info(`To get started, run:
+  - cd ${projectName}
+  - npm install
+  - npm run dev`);
+};
+
 const handleAutocompleteNew = async () => {
-  const name = await p.text({ message: "Project Name", placeholder: "solid-project" });
+  const name = await p.text({ message: "Project Name", placeholder: "solid-project", defaultValue: "solid-project" });
+
   if (p.isCancel(name)) {
     p.log.warn("Canceled");
     return;
   }
+
+  const isStart = await p.confirm({ message: "Is this a Solid-Start project?" });
+
+  if (p.isCancel(isStart)) {
+    p.log.warn("Canceled");
+    return;
+  }
+
+  if (isStart) {
+    handleNewStartProject(name);
+    return;
+  }
+
   const template = await p.select({
     message: "Template",
     initialValue: "ts",
     options: localSupported.map((s) => ({ label: s, value: s })),
   });
+
   if (p.isCancel(template)) {
     p.log.warn("Canceled");
     return;
   }
+
   const pM = await detect();
   const projectName = name ?? "solid-project";
+
   const s = p.spinner();
   s.start("Creating project");
-  const { stdout } = await execa(
+
+  await execa(
     getRunner(pM),
     ["degit", `solidjs/templates/${template}`, projectName].filter((e) => e !== null) as string[],
   );
+
   s.stop("Project successfully created! 🎉");
+
   p.log.info(`To get started, run:
   - cd ${projectName}
   - npm install
@@ -49,6 +115,7 @@ export const handleNew = async (variation?: AllSupported, name?: string, stackbl
     await handleAutocompleteNew();
     return;
   }
+
   if (stackblitz) {
     const s = p.spinner();
     s.start(`Opening ${variation} in browser`);
@@ -57,14 +124,19 @@ export const handleNew = async (variation?: AllSupported, name?: string, stackbl
     p.log.success("Successfully Opened in Browser");
     return;
   }
+
   const pM = await detect();
+
   const s = p.spinner();
   s.start("Creating project");
-  const { stdout } = await execa(
+
+  await execa(
     getRunner(pM),
     ["degit", `solidjs/templates/${variation}`, name ?? null].filter((e) => e !== null) as string[],
   );
+
   s.stop("Project successfully created! 🎉");
+
   p.log.info(`To get started, run:
   - cd ${name}
   - npm install

--- a/packages/core/src/command_handlers/new.ts
+++ b/packages/core/src/command_handlers/new.ts
@@ -16,22 +16,27 @@ const getRunner = (pM: PM) => {
   }
 };
 const handleAutocompleteNew = async () => {
-  const project = await p.group({
-    name: () => p.text({ message: "Project Name", placeholder: "solid-project" }),
-    template: () =>
-      p.select({
-        message: "Template",
-        initialValue: "ts",
-        options: localSupported.map((s) => ({ label: s, value: s })),
-      }),
+  const name = await p.text({ message: "Project Name", placeholder: "solid-project" });
+  if (p.isCancel(name)) {
+    p.log.warn("Canceled");
+    return;
+  }
+  const template = await p.select({
+    message: "Template",
+    initialValue: "ts",
+    options: localSupported.map((s) => ({ label: s, value: s })),
   });
+  if (p.isCancel(template)) {
+    p.log.warn("Canceled");
+    return;
+  }
   const pM = await detect();
-  const projectName = project.name ?? "solid-project";
+  const projectName = name ?? "solid-project";
   const s = p.spinner();
   s.start("Creating project");
   const { stdout } = await execa(
     getRunner(pM),
-    ["degit", `solidjs/templates/${project.template}`, projectName].filter((e) => e !== null) as string[],
+    ["degit", `solidjs/templates/${template}`, projectName].filter((e) => e !== null) as string[],
   );
   s.stop("Project successfully created! 🎉");
   p.log.info(`To get started, run:
@@ -53,8 +58,15 @@ export const handleNew = async (variation?: AllSupported, name?: string, stackbl
     return;
   }
   const pM = await detect();
+  const s = p.spinner();
+  s.start("Creating project");
   const { stdout } = await execa(
     getRunner(pM),
     ["degit", `solidjs/templates/${variation}`, name ?? null].filter((e) => e !== null) as string[],
   );
+  s.stop("Project successfully created! 🎉");
+  p.log.info(`To get started, run:
+  - cd ${name}
+  - npm install
+  - npm run dev`);
 };

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -39,7 +39,18 @@ const new_ = command({
     stackblitz: flag({ type: boolean, long: "stackblitz", short: "s" }),
   },
   async handler({ variation, name, stackblitz }) {
-    if (!name) name = `solid-${variation}`;
+    if (!name) {
+      const _name = await p.text({
+        message: "Project Name",
+        placeholder: `solid-${variation}`,
+        defaultValue: `solid-${variation}`,
+      });
+      if (p.isCancel(_name)) {
+        p.log.warn("Canceled");
+        return;
+      }
+      name = _name;
+    }
     await handleNew(variation, name, stackblitz);
   },
 });

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -39,7 +39,7 @@ const new_ = command({
     stackblitz: flag({ type: boolean, long: "stackblitz", short: "s" }),
   },
   async handler({ variation, name, stackblitz }) {
-    if (!name) {
+    if (!name && variation) {
       const _name = await p.text({
         message: "Project Name",
         placeholder: `solid-${variation}`,


### PR DESCRIPTION
Added support for creating Solid-Start projects with the `solid new` command
Added input for specifying name for project when variation is provided but name is not
Added whitespace and formatting