### PR TITLE
Integrations and `cancelable` utility function

### DIFF
--- a/packages/core/src/command_handlers/add.ts
+++ b/packages/core/src/command_handlers/add.ts
@@ -1,6 +1,6 @@
 import { writeFile } from "fs/promises";
 import { autocomplete } from "../components/autocomplete/autocomplete";
-import { S_BAR } from "../components/autocomplete/utils";
+import { S_BAR, cancelable } from "../components/autocomplete/utils";
 import { Integrations, Supported, integrations, transformPlugins } from "../lib/transform";
 import * as p from "@clack/prompts";
 import color from "picocolors";
@@ -12,35 +12,29 @@ const handleAutocompleteAdd = async () => {
   const supportedIntegrations = (Object.keys(integrations) as Supported[]).map((value) => ({ label: value, value }));
   const opts = () => [...supportedIntegrations, ...primitives()];
   loadPrimitives().catch((e) => p.log.error(e));
-  const a = await autocomplete({
-    message: "Add packages",
-    options: opts,
-  });
-
-  if (p.isCancel(a)) {
-    p.log.warn("Canceled");
-    return;
-  }
+  const a = await cancelable(
+    autocomplete({
+      message: "Add packages",
+      options: opts,
+    }),
+  );
 
   if (a.length === 0) {
     p.log.warn("Nothing selected");
     return;
   }
-  const shouldInstall = await p.select({
-    options: [
-      { label: "Yes", value: true },
-      { label: "No", value: false },
-      { label: "Yes (force)", value: [true, "force"] },
-    ],
-    message: `Install the following (${a.length}) packages? \n${color.red(S_BAR)} \n${color.red(S_BAR)}  ${
-      " " + color.yellow(a.map((opt) => opt.label).join(" ")) + " "
-    } \n${color.red(S_BAR)} `,
-  });
-
-  if (p.isCancel(shouldInstall)) {
-    p.log.warn("Canceled");
-    return;
-  }
+  const shouldInstall = await cancelable<unknown>(
+    p.select({
+      options: [
+        { label: "Yes", value: true },
+        { label: "No", value: false },
+        { label: "Yes (force)", value: [true, "force"] },
+      ],
+      message: `Install the following (${a.length}) packages? \n${color.red(S_BAR)} \n${color.red(S_BAR)}  ${
+        " " + color.yellow(a.map((opt) => opt.label).join(" ")) + " "
+      } \n${color.red(S_BAR)} `,
+    }),
+  );
 
   if (!shouldInstall) return;
 

--- a/packages/core/src/command_handlers/new.ts
+++ b/packages/core/src/command_handlers/new.ts
@@ -2,6 +2,7 @@ import * as p from "@clack/prompts";
 import { openInBrowser } from "../lib/utils/open";
 import { PM, detect } from "detect-package-manager";
 import { execa } from "execa";
+import { cancelable } from "../components/autocomplete/utils";
 
 const startSupported = [
   "bare",
@@ -33,16 +34,13 @@ const getRunner = (pM: PM) => {
 };
 
 const handleNewStartProject = async (projectName: string) => {
-  const template = await p.select({
-    message: "Which template would you like to use?",
-    initialValue: "ts",
-    options: startSupported.map((s) => ({ label: s, value: s })),
-  });
-
-  if (p.isCancel(template)) {
-    p.log.warn("Canceled");
-    return;
-  }
+  const template = await cancelable(
+    p.select({
+      message: "Which template would you like to use?",
+      initialValue: "ts",
+      options: startSupported.map((s) => ({ label: s, value: s })),
+    }),
+  );
 
   const pM = await detect();
   const s = p.spinner();
@@ -62,35 +60,24 @@ const handleNewStartProject = async (projectName: string) => {
 };
 
 const handleAutocompleteNew = async () => {
-  const name = await p.text({ message: "Project Name", placeholder: "solid-project", defaultValue: "solid-project" });
+  const name = await cancelable(
+    p.text({ message: "Project Name", placeholder: "solid-project", defaultValue: "solid-project" }),
+  );
 
-  if (p.isCancel(name)) {
-    p.log.warn("Canceled");
-    return;
-  }
-
-  const isStart = await p.confirm({ message: "Is this a Solid-Start project?" });
-
-  if (p.isCancel(isStart)) {
-    p.log.warn("Canceled");
-    return;
-  }
+  const isStart = await cancelable(p.confirm({ message: "Is this a Solid-Start project?" }));
 
   if (isStart) {
     handleNewStartProject(name);
     return;
   }
 
-  const template = await p.select({
-    message: "Template",
-    initialValue: "ts",
-    options: localSupported.map((s) => ({ label: s, value: s })),
-  });
-
-  if (p.isCancel(template)) {
-    p.log.warn("Canceled");
-    return;
-  }
+  const template = await cancelable(
+    p.select({
+      message: "Template",
+      initialValue: "ts",
+      options: localSupported.map((s) => ({ label: s, value: s })),
+    }),
+  );
 
   const pM = await detect();
   const projectName = name ?? "solid-project";

--- a/packages/core/src/command_handlers/new.ts
+++ b/packages/core/src/command_handlers/new.ts
@@ -22,7 +22,7 @@ const localSupported = ["ts", "js"] as const;
 const stackblitzSupported = ["bare"] as const;
 
 type AllSupported = (typeof localSupported)[number] | (typeof stackblitzSupported)[number];
-const getRunner = (pM: PM) => {
+export const getRunner = (pM: PM) => {
   switch (pM) {
     case "npm":
       return "npx";

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -7,6 +7,7 @@ import { boolean, command, flag, optional, positional, restPositionals, string }
 import { oneOf } from "../lib/utils/oneOf";
 import { handleAdd } from "../command_handlers/add";
 import { handleNew } from "../command_handlers/new";
+import { cancelable } from "../components/autocomplete/utils";
 
 const add = command({
   name: "add",
@@ -40,15 +41,13 @@ const new_ = command({
   },
   async handler({ variation, name, stackblitz }) {
     if (!name && variation) {
-      const _name = await p.text({
-        message: "Project Name",
-        placeholder: `solid-${variation}`,
-        defaultValue: `solid-${variation}`,
-      });
-      if (p.isCancel(_name)) {
-        p.log.warn("Canceled");
-        return;
-      }
+      const _name = await cancelable(
+        p.text({
+          message: "Project Name",
+          placeholder: `solid-${variation}`,
+          defaultValue: `solid-${variation}`,
+        }),
+      );
       name = _name;
     }
     await handleNew(variation, name, stackblitz);

--- a/packages/core/src/components/autocomplete/utils.ts
+++ b/packages/core/src/components/autocomplete/utils.ts
@@ -1,3 +1,5 @@
+import { isCancel } from "@clack/core";
+import { log } from "@clack/prompts";
 import color from "picocolors";
 // Taken from https://github.com/natemoo-re/clack/blob/main/packages/prompts/src/index.ts#L642
 const S_STEP_ACTIVE = "◆";
@@ -80,4 +82,15 @@ export {
   S_STEP_SUBMIT,
 };
 
-export { strip, box };
+const cancelable = async <T = unknown>(prompt: Promise<T | symbol>, cancelMessage: string = "Canceled"): Promise<T> => {
+  const value = await prompt;
+
+  if (isCancel(value)) {
+    log.warn(cancelMessage);
+    process.exit(0);
+  }
+
+  return value;
+};
+
+export { strip, box, cancelable };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,12 +9,14 @@ import { handleMode } from "./command_handlers/start/mode";
 import { handleAdapter } from "./command_handlers/start/adapter";
 import { handleData } from "./command_handlers/start/data";
 import { handleRoute } from "./command_handlers/start/route";
+
 const possibleActions = [
   { value: "add", label: "Add an integration", hint: "solid add ..." },
   { value: "new", label: "Create new project", hint: "solid new ..." },
   { value: "start", label: "A start specific action", hint: "solid start ..." },
 ] as const;
-const provideStartSuggestions = async () => {
+
+export const provideStartSuggestions = async () => {
   let startAction = await p.select({
     message: "Select a start action",
     options: [
@@ -43,6 +45,7 @@ const provideStartSuggestions = async () => {
       break;
   }
 };
+
 const provideSuggestions = async () => {
   type ActionType = (typeof possibleActions)[number]["value"];
   let action = (await p.select({
@@ -63,6 +66,7 @@ const provideSuggestions = async () => {
       break;
   }
 };
+
 const main = async () => {
   const cli = subcommands({
     name: "solid",
@@ -70,10 +74,17 @@ const main = async () => {
   });
   p.intro(`${color.bgCyan(color.black(" Solid-CLI "))}`);
   const args = process.argv.slice(2);
+
   if (args.length === 0) {
     await provideSuggestions();
     return;
   }
+
+  if (args.length === 1 && args[0] === "start") {
+    await provideStartSuggestions();
+    return;
+  }
+
   run(cli, args);
 };
 main();

--- a/packages/core/src/lib/transform.ts
+++ b/packages/core/src/lib/transform.ts
@@ -45,7 +45,11 @@ export type PluginOptions = {
   options: object;
 };
 
-export type IntegrationsValue = { pluginOptions: PluginOptions; postInstall?: () => Promise<void> };
+export type IntegrationsValue = {
+  pluginOptions?: PluginOptions;
+  installs: string[];
+  postInstall?: () => Promise<void>;
+};
 
 export type Integrations = Record<Supported, IntegrationsValue>;
 
@@ -57,6 +61,7 @@ export const integrations = {
       isDefault: true,
       options: {},
     },
+    installs: ["unocss"],
     postInstall: async () => {
       await insertAtBeginning(await getProjectRoot(), `import "virtual:uno.css";\n`);
     },
@@ -68,6 +73,7 @@ export const integrations = {
       isDefault: false,
       options: {},
     },
+    installs: ["vite-plugin-pwa"],
     postInstall: async () => {
       await insertAtBeginning(await getProjectRoot(), `import "solid-devtools";\n`);
     },
@@ -79,5 +85,6 @@ export const integrations = {
       isDefault: true,
       options: {},
     },
+    installs: ["solid-devtools"],
   },
 };


### PR DESCRIPTION
Added `cancelable` utility function to wrap prompts to handle if user cancels
Updated integrations to include installs string array for what to install for integrations
Updated integrations to have pluginOptions be optional
Moved postInstall to be after plugin installs are complete