### PR TITLE
refactor: remove unused (and duplicate) function

### DIFF
--- a/packages/commands/src/handlers/add.ts
+++ b/packages/commands/src/handlers/add.ts
@@ -75,17 +75,6 @@ const transformPrimitives = async (ps: string[]) => {
 	const mappedInput = ps.map((p) => p.replace("@solid-primitives/", ""));
 	return primitives().filter((p) => mappedInput.includes(p.value.replace("@solid-primitives/", "")));
 };
-// @ts-ignore
-const installCommand = async (pM: PM): Promise<string> => {
-	switch (pM) {
-		case "npm":
-			return "install";
-		case "yarn":
-			return "add";
-		case "pnpm":
-			return "add";
-	}
-};
 type Configs = Integrations[keyof Integrations][];
 export const handleAdd = async (packages?: string[], forceTransform: boolean = false) => {
 	if (!packages?.length) {


### PR DESCRIPTION
This function is unused, and there is code doing the same task at https://github.com/solidjs-community/solid-cli/blob/main/packages/utils/src/updates/index.ts#L21-L32. It isn't used right now as I just mentioned but we could potentially move that function to https://github.com/solidjs-community/solid-cli/tree/main/packages/utils/src/detect-package-manager or something to just have one place for it in the future.