### PR TITLE
add .vinxi build folder to .gitignore

### DIFF
--- a/packages/commands/src/handlers/new.ts
+++ b/packages/commands/src/handlers/new.ts
@@ -16,6 +16,7 @@ dist
 .vercel
 .netlify
 netlify
+.vinxi
 
 # Environment
 .env


### PR DESCRIPTION
When using the tool to create a solid start project, the .gitignore file doesn't include .vinxi, but that folder is generated when you run `npm run dev`. This adds it to the .gitignore, so git doesn't try to track it when you build the project.

Issue mentioned by me here
https://github.com/solidjs/solid-start/issues/1340

Before I found this other repo :)