### PR TITLE
add some CLI args to the `create-solid` command

### DIFF
--- a/packages/commands/src/handlers/new.ts
+++ b/packages/commands/src/handlers/new.ts
@@ -132,7 +132,7 @@ const handleTSConversion = async (tempDir: string, projectName: string) => {
 	});
 };
 
-const handleNewStartProject = async (projectName: string) => {
+const handleNewStartProject = async (projectName: string, variation?: AllSupported) => {
 	const template = await cancelable(
 		p.select({
 			message: t.NEW_START,
@@ -142,7 +142,7 @@ const handleNewStartProject = async (projectName: string) => {
 		}),
 	);
 
-	const withTs = await cancelable(p.confirm({ message: "Use Typescript?" }));
+	const withTs = variation ? variation !== "ts" : await cancelable(p.confirm({ message: "Use Typescript?" }));
 
 	// If the user does not want ts, we create the project in a temp directory inside the project directory
 	const tempDir = withTs ? projectName : join(projectName, ".solid-start");
@@ -173,12 +173,8 @@ const handleNewStartProject = async (projectName: string) => {
   - npm run dev`);
 };
 
-const handleAutocompleteNew = async () => {
-	const name = await cancelable(
-		p.text({ message: t.PROJECT_NAME, placeholder: "solid-project", defaultValue: "solid-project" }),
-	);
-
-	const isStart = await cancelable(p.confirm({ message: t.IS_START_PROJECT }));
+const handleAutocompleteNew = async (name: string, isStart?: boolean) => {
+	isStart ??= await cancelable(p.confirm({ message: t.IS_START_PROJECT }));
 
 	if (isStart) {
 		handleNewStartProject(name);
@@ -197,11 +193,16 @@ const handleAutocompleteNew = async () => {
 };
 export const handleNew = async (
 	variation?: AllSupported,
-	name: string = "solid-project",
+	name?: string,
 	stackblitz: boolean = false,
+	isStart?: boolean,
 ) => {
+	name ??= await cancelable(
+		p.text({ message: t.PROJECT_NAME, placeholder: "solid-project", defaultValue: "solid-project" }),
+	);
+
 	if (!variation) {
-		await handleAutocompleteNew();
+		await handleAutocompleteNew(name, isStart);
 		return;
 	}
 
@@ -214,7 +215,7 @@ export const handleNew = async (
 		return;
 	}
 
-	const withTs = await cancelable(p.confirm({ message: "Use Typescript?" }));
+	const withTs = variation ? variation === "ts" : await cancelable(p.confirm({ message: "Use Typescript?" }));
 
 	// If the user does not want ts, we create the project in a temp directory inside the project directory
 	const tempDir = withTs ? name : join(name, ".solid-start");

--- a/packages/create-solid/package.json
+++ b/packages/create-solid/package.json
@@ -39,5 +39,7 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"dependencies": {}
+	"dependencies": {
+		"commander": "^12.0.0"
+	}
 }

--- a/packages/create-solid/package.json
+++ b/packages/create-solid/package.json
@@ -30,6 +30,7 @@
 	},
 	"devDependencies": {
 		"@solid-cli/commands": "workspace:*",
+		"@solid-cli/utils": "workspace:*",
 		"jiti": "^1.21.0",
 		"tsup": "^8.0.2",
 		"typescript": "^5.3.3",

--- a/packages/create-solid/src/index.ts
+++ b/packages/create-solid/src/index.ts
@@ -4,17 +4,18 @@ import color from "picocolors";
 import { intro } from "@clack/prompts";
 import { version } from "../package.json";
 import { program } from "commander";
+import { t } from "@solid-cli/utils";
 
 intro(`\n${color.bgCyan(color.black(` Create-Solid v${version}`))}`);
 
 program
 	.allowExcessArguments(false)
 	.configureHelp({
-		commandUsage: () => "create-solid [options]",
+		commandUsage: () => `create-solid [${t.OPTIONS}]`,
 	})
-	.helpOption(undefined, "Shows this help message")
-	.option("-p, --project-name <VALUE>", "The name of your project")
-	.option("-s, --solid-start", "Create a SolidStart project");
+	.helpOption(undefined, t.SHOWS_THIS_HELP_MESSAGE)
+	.option(`-p, --project-name <${t.VALUE}>`, t.NAME_OF_YOUR_PROJECT)
+	.option("-s, --solid-start", t.CREATE_START_PROJECT);
 
 program.parse();
 const { projectName, solidStart } = program.opts<{

--- a/packages/create-solid/src/index.ts
+++ b/packages/create-solid/src/index.ts
@@ -3,5 +3,23 @@ import { handleNew } from "@solid-cli/commands/new";
 import color from "picocolors";
 import { intro } from "@clack/prompts";
 import { version } from "../package.json";
+import { program } from "commander";
+
 intro(`\n${color.bgCyan(color.black(` Create-Solid v${version}`))}`);
-handleNew();
+
+program
+	.allowExcessArguments(false)
+	.configureHelp({
+		commandUsage: () => "create-solid [options]",
+	})
+	.helpOption(undefined, "Shows this help message")
+	.option("-p, --project-name <VALUE>", "The name of your project")
+	.option("-s, --solid-start", "Create a SolidStart project");
+
+program.parse();
+const { projectName, solidStart } = program.opts<{
+	projectName?: string;
+	solidStart?: boolean;
+}>();
+
+handleNew(undefined, projectName, false, solidStart);

--- a/packages/utils/src/translations/translations.ts
+++ b/packages/utils/src/translations/translations.ts
@@ -323,6 +323,36 @@ const TRANSLATIONS = {
 		fr: "Ouvert avec succès dans le navigateur",
 		ja: "ブラウザで正常に開きました",
 	},
+	OPTIONS: {
+		en: "options",
+		es: "opciones",
+		fr: "choix",
+		ja: "オプション",
+	},
+	SHOWS_THIS_HELP_MESSAGE: {
+		en: "Shows this help message",
+		es: "Muestra este mensaje de ayuda",
+		fr: "Affiche ce message d'aide",
+		ja: "このヘルプメッセージを表示します",
+	},
+	VALUE: {
+		en: "value",
+		es: "valor",
+		fr: "valeur",
+		ja: "価値",
+	},
+	NAME_OF_YOUR_PROJECT: {
+		en: "The name of your project",
+		es: "El nombre de tu proyecto",
+		fr: "Le nom de votre projet",
+		ja: "プロジェクトの名前",
+	},
+	CREATE_START_PROJECT: {
+		en: "Create a SolidStart project",
+		es: "Crear un proyecto SolidStart",
+		fr: "Créer un projet SolidStart",
+		ja: "SolidStart プロジェクトを作成する",
+	},
 } as const satisfies Translations;
 
 export const t = new Proxy(TRANSLATIONS, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 1.12.4
       vitest:
         specifier: ^1.3.1
-        version: 1.3.1
+        version: 1.3.1(@types/node@20.11.20)
 
   packages/commands:
     dependencies:
@@ -126,6 +126,10 @@ importers:
         version: 5.3.3
 
   packages/create-solid:
+    dependencies:
+      commander:
+        specifier: ^12.0.0
+        version: 12.0.0
     devDependencies:
       '@clack/prompts':
         specifier: 0.7.0
@@ -1735,6 +1739,11 @@ packages:
 
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  /commander@12.0.0:
+    resolution: {integrity: sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==}
+    engines: {node: '>=18'}
+    dev: false
 
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -3498,10 +3507,6 @@ packages:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
 
-  /std-env@3.6.0:
-    resolution: {integrity: sha512-aFZ19IgVmhdB2uX599ve2kE6BIE3YMnQ6Gp6BURhW/oIzpXGKr878TQfAQZn1+i0Flcc/UKUy1gOlcfaUBCryg==}
-    dev: true
-
   /std-env@3.7.0:
     resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
     dev: true
@@ -3661,10 +3666,6 @@ packages:
       tiny-colors: 2.0.2
       when-exit: 2.1.1
     dev: false
-
-  /tinybench@2.5.1:
-    resolution: {integrity: sha512-65NKvSuAVDP/n4CqH+a9w2kTlLReS9vhsAP06MWx+/89nMinJyB2icyl58RIcqCmIggpojIGeuJGhjU1aGMBSg==}
-    dev: true
 
   /tinybench@2.6.0:
     resolution: {integrity: sha512-N8hW3PG/3aOoZAN5V/NSAEDz0ZixDSSt5b/a05iqtpgfLWMSVuCo7w0k2vVvEjdrIoeGqZzweX2WlyioNIHchA==}
@@ -3994,7 +3995,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vite@5.1.4:
+  /vite@5.1.4(@types/node@20.11.20):
     resolution: {integrity: sha512-n+MPqzq+d9nMVTKyewqw6kSt+R3CkvF9QAKY8obiQn8g1fwTscKxyfaYnC632HtBXAQGc1Yjomphwn1dtwGAHg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -4022,66 +4023,12 @@ packages:
       terser:
         optional: true
     dependencies:
+      '@types/node': 20.11.20
       esbuild: 0.19.12
       postcss: 8.4.35
       rollup: 4.12.0
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
-
-  /vitest@1.3.1:
-    resolution: {integrity: sha512-/1QJqXs8YbCrfv/GPQ05wAZf2eakUPLPa18vkJAKE7RXOKfVHqMZZ1WlTjiwl6Gcn65M5vpNUB6EFLnEdRdEXQ==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 1.3.1
-      '@vitest/ui': 1.3.1
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-    dependencies:
-      '@vitest/expect': 1.3.1
-      '@vitest/runner': 1.3.1
-      '@vitest/snapshot': 1.3.1
-      '@vitest/spy': 1.3.1
-      '@vitest/utils': 1.3.1
-      acorn-walk: 8.3.2
-      chai: 4.4.1
-      debug: 4.3.4(supports-color@5.5.0)
-      execa: 8.0.1
-      local-pkg: 0.5.0
-      magic-string: 0.30.7
-      pathe: 1.1.2
-      picocolors: 1.0.0
-      std-env: 3.7.0
-      strip-literal: 2.0.0
-      tinybench: 2.6.0
-      tinypool: 0.8.2
-      vite: 5.1.4
-      vite-node: 1.3.1(@types/node@20.11.20)
-      why-is-node-running: 2.2.2
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
     dev: true
 
   /vitest@1.3.1(@types/node@20.11.20):
@@ -4116,18 +4063,18 @@ packages:
       '@vitest/spy': 1.3.1
       '@vitest/utils': 1.3.1
       acorn-walk: 8.3.2
-      chai: 4.3.10
+      chai: 4.4.1
       debug: 4.3.4(supports-color@5.5.0)
       execa: 8.0.1
       local-pkg: 0.5.0
-      magic-string: 0.30.5
-      pathe: 1.1.1
+      magic-string: 0.30.7
+      pathe: 1.1.2
       picocolors: 1.0.0
-      std-env: 3.6.0
+      std-env: 3.7.0
       strip-literal: 2.0.0
-      tinybench: 2.5.1
+      tinybench: 2.6.0
       tinypool: 0.8.2
-      vite: 5.0.10(@types/node@20.11.20)
+      vite: 5.1.4(@types/node@20.11.20)
       vite-node: 1.3.1(@types/node@20.11.20)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       '@solid-cli/commands':
         specifier: workspace:*
         version: link:../commands
+      '@solid-cli/utils':
+        specifier: workspace:*
+        version: link:../utils
       jiti:
         specifier: ^1.21.0
         version: 1.21.0


### PR DESCRIPTION
Hi 👋 

This PR proposes changes to allow `create-solid` to accept CLI arguments

As you can see from the command's help message here:
![Screenshot 2024-03-02 at 18 37 07](https://github.com/solidjs-community/solid-cli/assets/61631103/0a998573-e142-4708-a7a7-5fcc70f84590)

This allows flexibility for the user to make choices either via cli arguments or via the interactive interface.

For example, running the following will create a project without interactively asking the user for the project's name and if they want to use solidStart:
```sh
npx create-solid -p my-solid-project -s
```

This PR introduces just a couple of CLI arguments, more can be added later, but anyways I just wanted to test the water and see if there's interest in this and if the chosen approach (using `commander`) is accepted.

Please have a look and let me know what you think 🙏 