### PR TITLE
feat: vitest integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A custom-built CLI for creating and managing SolidJS apps and projects.
   - [ ] PostCSS
   - [x] UnoCSS
   - [ ] Vanilla Extract
-  - [ ] Vitest
+  - [x] Vitest
   - [ ] Tauri
   - [ ] Playwright
 - [ ] Utilities


### PR DESCRIPTION
This adds a vitest integration that will

* install the neccessities (vitest, jsdom, some testing-library goodies)
* add a test script in package.json
* add implicitly used types to tsconfig.json if using TS and not already present
* add a vitest.config.[ts|mjs] if there is no vite(st).config.*

