### PR TITLE
remove generic netlify folder from the gitignore

### DIFF
--- a/packages/commands/src/handlers/new.ts
+++ b/packages/commands/src/handlers/new.ts
@@ -16,7 +16,6 @@ dist
 .output
 .vercel
 .netlify
-netlify
 .vinxi
 
 # Environment


### PR DESCRIPTION
We need this so devs can enable netlify features directly.