### PR TITLE
`pnpm create solid@latest myprojname basic` yields `Template "basic" is not supported`

### DIFF
--- a/packages/commands/src/handlers/new.ts
+++ b/packages/commands/src/handlers/new.ts
@@ -176,11 +176,11 @@ ${pM.name} ${pM.runScriptCommand("dev")}`,
 	);
 };
 
-const handleAutocompleteNew = async (name: string, isStart?: boolean) => {
+const handleAutocompleteNew = async (name: string, template?: Template, isStart?: boolean) => {
 	isStart ??= await cancelable(p.confirm({ message: t.IS_START_PROJECT }));
 
 	if (isStart) {
-		handleNewStartProject(name);
+		handleNewStartProject(name, template);
 		return;
 	}
 
@@ -208,7 +208,7 @@ export const handleNew = async (
 	);
 
 	if (!x.extension) {
-		await handleAutocompleteNew(x.name, x.isStart);
+		await handleAutocompleteNew(x.name, x.template, x.isStart);
 		return;
 	}
 

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -28,7 +28,7 @@ const new_ = command({
 	description: t.NEW_DESC,
 	args: {
 		variation: positional({
-			type: optional(oneOf(["bare", "ts", "js"] as const)),
+			type: optional(oneOf(["ts", "js"] as const)),
 			displayName: t.NEW_VARIATION_DESC,
 			description: "",
 		}),
@@ -50,7 +50,7 @@ const new_ = command({
 			);
 			name = _name;
 		}
-		await handleNew(variation, name, stackblitz);
+		await handleNew({ extension: variation, name, stackblitz });
 	},
 });
 

--- a/packages/create-solid/src/index.ts
+++ b/packages/create-solid/src/index.ts
@@ -1,5 +1,5 @@
 #! /usr/bin/env node
-import { AllSupported, handleNew, isSupported } from "@solid-cli/commands/new";
+import { Template, handleNew, isTemplate } from "@solid-cli/commands/new";
 import color from "picocolors";
 import { intro } from "@clack/prompts";
 import { version } from "../package.json";
@@ -35,17 +35,17 @@ const app = command({
 		}),
 	},
 	handler: async ({ projectNameOption, solidStart, projectNamePositional, templatePositional }) => {
-		if (templatePositional && !isSupported(templatePositional)) {
+		if (templatePositional && !isTemplate(templatePositional)) {
 			console.error(`Template "${templatePositional}" is not supported`);
 			process.exit(0);
 		}
 		try {
-			await handleNew(
-				templatePositional as AllSupported,
-				projectNamePositional ?? projectNameOption,
-				false,
-				solidStart,
-			);
+			await handleNew({
+				template: templatePositional as Template,
+				name: projectNamePositional ?? projectNameOption,
+				stackblitz: false,
+				isStart: solidStart,
+			});
 		} catch (e) {
 			console.error(e);
 			process.exit(1);


### PR DESCRIPTION
This PR fixes the title error—apologies for the large-ish PR.

IMO the bug occurred due to confusing naming, so I changed... uh... a lot of names. There is still opportunity to add a flag for ts/js, but I stopped here for a more minimal PR.

I removed the  `bare` "variant" because the stackblitz works with `ts` or  `js`, and I'm not sure why it was there initially. (Honestly they all lead to the same Stackblitz anyway.)