### PR TITLE
refactor: change Solid-Start to SolidStart

### DIFF
--- a/docs/vitepress_docs/.vitepress/config.ts
+++ b/docs/vitepress_docs/.vitepress/config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
 					{ text: "About", link: "/about" },
 					{ text: "Installation", link: "/installation" },
 					{ text: "Basic Commands", link: "/basic-commands" },
-					{ text: "Solid-Start Commands", link: "/start-commands" },
+					{ text: "SolidStart Commands", link: "/start-commands" },
 				],
 			},
 			{ text: "Supported Integrations", link: "/supported-integrations" },

--- a/docs/vitepress_docs/start-commands.md
+++ b/docs/vitepress_docs/start-commands.md
@@ -1,4 +1,4 @@
-# Solid-Start Commands
+# SolidStart Commands
 
 ### `Mode`
 
@@ -39,7 +39,7 @@ Creates a new route file in the file routes directory.
 solid start adapter
 ```
 
-Used to setup a Solid-Start specific adapter.
+Used to setup a SolidStart specific adapter.
 
 **Options**
 

--- a/packages/utils/src/translations/translations.ts
+++ b/packages/utils/src/translations/translations.ts
@@ -78,9 +78,9 @@ const TRANSLATIONS = {
 		ja: "作成するフォルダーの名前",
 	},
 	IS_START_PROJECT: {
-		en: "Is this a Solid-Start project?",
-		es: "¿Es este un proyecto de Solid-Start?",
-		fr: "Est-ce un projet Solid-Start ?",
+		en: "Is this a SolidStart project?",
+		es: "¿Es este un proyecto de SolidStart?",
+		fr: "Est-ce un projet SolidStart?",
 		ja: "これはソリッドスタートプロジェクトですか?",
 	},
 	START_MODE: {


### PR DESCRIPTION
Right now, the CLI prints `Solid-Start` instead of `SolidStart`. This causes some confusion to some people on how to write SolidStart 😅 
This PR changes the text references to SolidStart