### PR TITLE
add app.config.timestamp_*.js to gitignore

### DIFF
--- a/packages/commands/src/handlers/new.ts
+++ b/packages/commands/src/handlers/new.ts
@@ -17,6 +17,7 @@ dist
 .vercel
 .netlify
 .vinxi
+app.config.timestamp_*.js
 
 # Environment
 .env


### PR DESCRIPTION
Without this, lots of files like `app.config.timestamp_1724527617030.js` are making some noise:

<img width="402" alt="Screenshot 2024-08-24 at 1 49 45 PM" src="https://github.com/user-attachments/assets/6e21d6a5-098c-4ff7-8de4-a0cb4ebba12d">
