### PR TITLE
Add  with { type: "json" } to package.json import

### DIFF
--- a/packages/create-solid/src/index.ts
+++ b/packages/create-solid/src/index.ts
@@ -2,10 +2,10 @@
 import { AllSupported, handleNew, isSupported } from "@solid-cli/commands/new";
 import color from "picocolors";
 import { intro } from "@clack/prompts";
-import { version } from "../package.json";
+import packageJson from "../package.json" with { type: "json" };
 import { command, run, option, string, boolean, flag, optional, positional } from "cmd-ts";
 
-intro(`\n${color.bgCyan(color.black(` Create-Solid v${version}`))}`);
+intro(`\n${color.bgCyan(color.black(` Create-Solid v${packageJson.version}`))}`);
 
 const app = command({
 	name: "create-solid",


### PR DESCRIPTION
This makes it possible to execute the create-solid package locally with deno:

`deno run -A --unstable-bare-node-builtins ./packages/create-solid/src/index.ts`

In .js, node can't resolve named imports directly from json either, like deno, it's only bun that supports that directly for .js/.ts 

See
- https://github.com/denoland/deno/pull/26639#issuecomment-2447626980

Towards
- https://github.com/solidjs-community/solid-cli/issues/55

