### PR TITLE
Add deno support for solid cli

### DIFF
--- a/packages/utils/src/package-manager/index.ts
+++ b/packages/utils/src/package-manager/index.ts
@@ -37,7 +37,7 @@ export const detectPackageManager = (): PackageManager => {
 				runner: "deno run",
 				installCommand: "add",
 				runScriptCommand(s) {
-					return s;
+					return `task ${s}`;
 				},
 			};
 		default:

--- a/packages/utils/src/package-manager/index.ts
+++ b/packages/utils/src/package-manager/index.ts
@@ -31,6 +31,15 @@ export const detectPackageManager = (): PackageManager => {
 					return s;
 				},
 			};
+		case userAgent.startsWith("deno"):
+			return {
+				name: "deno",
+				runner: "deno run",
+				installCommand: "add",
+				runScriptCommand(s) {
+					return s;
+				},
+			};
 		default:
 			return {
 				name: "npm",


### PR DESCRIPTION
Deno now supports `process.env.npm_config_user_agent`
- https://github.com/denoland/deno/pull/26639

Making it possible to add the deno installer to this project, so we can make this green

<img width="750" alt="Screenshot 2024-11-01 at 19 56 46" src="https://github.com/user-attachments/assets/3467e3c0-38b1-469b-af95-33d28c07ca63">
