### PR TITLE
with-vite-plugin-pages

### DIFF
--- a/packages/create/src/utils/constants.ts
+++ b/packages/create/src/utils/constants.ts
@@ -50,7 +50,7 @@ const VANILLA_TEMPLATES = [
 	"with-tailwindcss",
 	"with-sass",
 	"with-solid-router",
-	"with-pages-router-file-based",
+	"with-vite-plugin-pages",
 	"with-tanstack-router-config-based",
 	"with-tanstack-router-file-based",
 	"with-jest",


### PR DESCRIPTION
Updating the name of this template to with-vite-plugin-pages, because it's more accurate than with-pages-router-file-based