### PR TITLE
link tanstack start example

### DIFF
--- a/packages/create/src/utils/constants.ts
+++ b/packages/create/src/utils/constants.ts
@@ -53,6 +53,7 @@ const VANILLA_TEMPLATES = [
 	"with-pages-router-file-based",
 	"with-tanstack-router-config-based",
 	"with-tanstack-router-file-based",
+	"with-tanstack-start",
 	"with-jest",
 	"with-bootstrap",
 ] as const satisfies string[];


### PR DESCRIPTION
Adds the vanilla/with-tanstack-start example that's missing in the creation cli. @Tommypop2 , this should be ready to go.