### PR TITLE
Fix getting started command when directory is "."

### DIFF
--- a/packages/create/src/index.ts
+++ b/packages/create/src/index.ts
@@ -159,8 +159,8 @@ export const createSolid = (version: string) =>
 			// Next steps..
 			const pM = detectPackageManager();
 			p.note(
-				`cd ${projectName}
-${pM.name} install
+				projectName === "." ? "" : `cd ${projectName}\n` +
+				`${pM.name} install
 ${pM.name} ${pM.runScriptCommand("dev")}`,
 				"To get started, run:",
 			);


### PR DESCRIPTION
Before:
<img width="416" height="218" alt="image" src="https://github.com/user-attachments/assets/d24e5747-a959-4404-897b-0cd8f8e64173" />

After:
<img width="416" height="186" alt="post-pr-screenshot" src="https://github.com/user-attachments/assets/efcf9e37-373e-43f6-93b4-8a016f5f2490" />

If the user invokes
```
create solid@latest .
```

(PS; this was commited via github UI, so linting and verification still required)