### PR TITLE
feat: detect nub package manager

### DIFF
--- a/packages/utils/src/package-manager/index.ts
+++ b/packages/utils/src/package-manager/index.ts
@@ -40,6 +40,15 @@ export const detectPackageManager = (): PackageManager => {
 					return `task ${s}`;
 				},
 			};
+		case userAgent.startsWith("nub"):
+			return {
+				name: "nub",
+				runner: "nubx",
+				installCommand: "add",
+				runScriptCommand(s) {
+					return `run ${s}`;
+				},
+			};
 		default:
 			return {
 				name: "npm",


### PR DESCRIPTION
When invoked through nub, solid-cli falls through to the npm default. `detectPackageManager` switches on `npm_config_user_agent`; [nub](https://nubjs.com) advertises `nub/<version>`, which isn't matched.

nub is a Rust CLI with a pnpm-compatible command grammar. This adds a `nub` case: `runner: "nubx"` (its executor) and `installCommand: "add"`. `runScriptCommand` returns `run ${s}` rather than the bare script that pnpm and bun use — nub has no implicit script shortcut, so scripts run via `nub run <script>`.
