### PR TITLE
fix: clean up v2 templates list

### DIFF
--- a/packages/create/src/utils/constants.ts
+++ b/packages/create/src/utils/constants.ts
@@ -86,21 +86,19 @@ export type StartTemplate = (typeof START_TEMPLATES)[number];
 const START_TEMPLATES_V2 = [
 	"basic",
 	"bare",
-	"with-solidbase",
-	"hackernews",
-	"notes",
 	"with-auth",
 	"with-authjs",
 	"with-drizzle",
 	"with-mdx",
 	"with-prisma",
 	"with-solid-styled",
+	"with-solidbase",
+	"with-strict-csp",
 	"with-tailwindcss",
+	"with-tanstack-router",
 	"with-trpc",
 	"with-unocss",
 	"with-vitest",
-	"with-strict-csp",
-	"with-tanstack-router",
 ] as const satisfies string[];
 
 export type StartTemplateV2 = (typeof START_TEMPLATES_V2)[number];

--- a/packages/create/src/utils/constants.ts
+++ b/packages/create/src/utils/constants.ts
@@ -74,7 +74,6 @@ const START_TEMPLATES = [
 	"with-prisma",
 	"with-solid-styled",
 	"with-tailwindcss",
-	"with-tanstack-router",
 	"with-trpc",
 	"with-unocss",
 	"with-vitest",


### PR DESCRIPTION
## Purpose 

This PR cleans up the v2 templates list to align with the [solidjs/templates](https://github.com/solidjs/templates) repository.

## Context
The template list is currently hardcoded in `constants.ts`.
but templates are fetched from the `solidjs/templates` repo. 

This mismatch can cause issues when templates are added/removed in the templates repo but not reflected here.

**Ref:** [solidjs/templates](https://github.com/solidjs/templates)

## Changes

- Removed non-v2 templates (`hackernews`, `notes`, v1 `with-solidbase`)
- Sorted the template list alphabetically for better maintainability

## Before/After
- `hackernews`
- `notes`
- `with-solidbase` (v1 version)

**Sorted order:**
`with-auth` → `with-authjs` → `with-drizzle` → `with-mdx` → `with-prisma` → `with-solid-styled` → `with-solidbase` → `with-strict-csp` → `with-tailwindcss`
→ `with-tanstack-router` → `with-trpc` → `with-unocss` → `with-vitest`

## Files Changed
- `packages/create/src/utils/constants.ts`

---

## Appendix: Future Automation Ideas

To keep the template list in sync with `solidjs/templates`, we could consider:

1. **GitHub Actions Approach**:
   - Set up a workflow that watches `solidjs/templates` repo changes
   - Automatically updates `constants.ts` when v2 templates are added/removed
   - Creates a PR for review
2. **Runtime Computation**:
   - Use GitHub API to fetch available templates dynamically
   - Cache the result to avoid API rate limits
   - Fallback to hardcoded list if API fails
Both approaches would eliminate manual maintenance and prevent sync issues. Thoughts?

p.s. Thank you for your efforts and for maintaining this project.