### PR TITLE
fix: restore with-tanstack-router in v1

### DIFF
--- a/packages/create/src/utils/constants.ts
+++ b/packages/create/src/utils/constants.ts
@@ -74,6 +74,7 @@ const START_TEMPLATES = [
 	"with-prisma",
 	"with-solid-styled",
 	"with-tailwindcss",
+	"with-tanstack-router",
 	"with-trpc",
 	"with-unocss",
 	"with-vitest",


### PR DESCRIPTION
## Purpose

Restore `with-tanstack-router` to the v1 template list.

It was previously removed from the v1 list by mistake in commit 64a6011 instead of v2.



- ref: #78