### PR TITLE
fix: remove with-tanstack-router in v2

### DIFF
--- a/packages/create/src/utils/constants.ts
+++ b/packages/create/src/utils/constants.ts
@@ -94,7 +94,6 @@ const START_TEMPLATES_V2 = [
 	"with-solidbase",
 	"with-strict-csp",
 	"with-tailwindcss",
-	"with-tanstack-router",
 	"with-trpc",
 	"with-unocss",
 	"with-vitest",


### PR DESCRIPTION
## Purpose

Remove `with-tanstack-router` from the v2 template list.

In commit 64a6011, `with-tanstack-router` was mistakenly removed from the v1 list instead of v2. 
This PR corrects it by removing `with-tanstack-router` from the v2 list.

## Details

- Once routerLoad is restored in the upcoming release of `solid-start`, with-tanstack-router is expected to work properly again.

- You can either wait for the next release before merging
- Or remove it now and re-add it once `with-tanstack-router` is updated to function properly.

p.s. Sorry for any confusion or hassle caused!😅