### PR TITLE
fix: use @solidjs/web as jsxImportSource in solid-v2 jsconfig

### DIFF
--- a/packages/create/src/utils/constants.ts
+++ b/packages/create/src/utils/constants.ts
@@ -38,11 +38,12 @@ export const JS_CONFIG = {
 	},
 };
 
-// The solid-v2 templates don't use the `~/*` path alias
+// The solid-v2 templates don't use the `~/*` path alias, and Solid 2.0's JSX
+// runtime lives in `@solidjs/web` (matches the templates' tsconfig.json)
 export const JS_CONFIG_SOLID_V2 = {
 	compilerOptions: {
 		jsx: "preserve",
-		jsxImportSource: "solid-js",
+		jsxImportSource: "@solidjs/web",
 	},
 };
 


### PR DESCRIPTION
## Summary
- Follow-up to #82, addressing @brenelz's review comment (https://github.com/solidjs-community/solid-cli/pull/82#discussion_r3762588618): the `jsconfig.json` written for JS variants of the Solid 2.0 templates used `jsxImportSource: "solid-js"`, but the solid-v2 templates' own `tsconfig.json` files all declare `"@solidjs/web"` — Solid 2.0's JSX runtime lives in `@solidjs/web`, and vite-plugin-solid 3.x compiles against it (`moduleName: '@solidjs/web'`).
- One-line constant change in `JS_CONFIG_SOLID_V2`; no changeset needed since the affected code is unreleased (covered by the existing `solid-v2-templates` changeset).

## Test plan
- [x] Root `pnpm test` — 16/16 passing

Made with [Cursor](https://cursor.com)