### PR TITLE
fix: dedupe extensions array in JS-converted solid-v2 vite config

### DIFF
--- a/packages/create/src/create-solid-v2.ts
+++ b/packages/create/src/create-solid-v2.ts
@@ -25,6 +25,22 @@ export const createSolidV2TS = async ({ template, destination, path = "solid-v2"
 	if (ssr) await applySsrFlip(destination);
 };
 
+/**
+ * Retarget `.ts`/`.tsx` filename mentions in converted text (vite config,
+ * README) to the transpiled `.js`/`.jsx` output. `.d.ts` files are deleted
+ * (not transpiled) by the conversion, so their mentions are left alone.
+ */
+export const retargetTSFilenames = (text: string) =>
+	text
+		.replace(/\.tsx\b/g, ".jsx")
+		.replace(/(?<!\.d)\.ts(?=[`'"])/g, ".js")
+		// The blanket `.tsx` rewrite leaves duplicates behind when an array lists
+		// both (`extensions: ['.jsx', '.tsx']` → `['.jsx', '.jsx']`) — dedupe.
+		.replace(/extensions:\s*\[([^\]]*)\]/g, (_match, entries: string) => {
+			const deduped = [...new Set(entries.split(",").map((entry) => entry.trim()).filter(Boolean))];
+			return `extensions: [${deduped.join(", ")}]`;
+		});
+
 export const createSolidV2JS = async (args: CreateSolidV2Args, ssr?: boolean) => {
 	// Create typescript project in `<destination>/.project`
 	// then transpile this to javascript and clean up.
@@ -34,15 +50,13 @@ export const createSolidV2JS = async (args: CreateSolidV2Args, ssr?: boolean) =>
 	await createSolidV2TS({ ...args, destination: tempDir }, ssr);
 	await handleTSConversion(tempDir, args.destination, JS_CONFIG_SOLID_V2);
 	// Solid 2.0 templates have no `index.html` (turnkey entries), but their vite
-	// config references `.ts`/`.tsx` files by path (setup files, middleware, test
-	// globs) — retarget those to the transpiled `.js`/`.jsx` output
-	const viteConfigPath = join(args.destination, "vite.config.js");
-	if (existsSync(viteConfigPath)) {
-		const viteConfig = (await readFile(viteConfigPath))
-			.toString()
-			.replace(/\.tsx(?=['"])/g, ".jsx")
-			.replace(/\.ts(?=['"])/g, ".js");
-		await writeFile(viteConfigPath, viteConfig);
+	// config and README reference `.ts`/`.tsx` files (setup files, comments,
+	// route examples) — retarget those to the transpiled `.js`/`.jsx` output
+	for (const file of ["vite.config.js", "README.md"]) {
+		const filePath = join(args.destination, file);
+		if (existsSync(filePath)) {
+			await writeFile(filePath, retargetTSFilenames((await readFile(filePath)).toString()));
+		}
 	}
 	// Add .gitignore
 	writeFileSync(join(args.destination, ".gitignore"), GIT_IGNORE);

--- a/packages/create/tests/ts-retarget.test.ts
+++ b/packages/create/tests/ts-retarget.test.ts
@@ -1,0 +1,28 @@
+import { expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { retargetTSFilenames } from "../src/create-solid-v2";
+
+const fixtureConfig = fileURLToPath(new URL("./fixtures/solid-v2-basic/vite.config.ts", import.meta.url));
+
+it("dedupes the extensions array instead of writing ['.jsx', '.jsx']", () => {
+	const converted = retargetTSFilenames(readFileSync(fixtureConfig).toString());
+
+	expect(converted).toContain("extensions: ['.jsx']");
+	expect(converted).not.toContain("'.tsx'");
+	expect(converted).not.toContain("'.jsx', '.jsx'");
+	// Setup files are transpiled alongside the rest of the template
+	expect(converted).toContain("./vitest-setup.js");
+});
+
+it("retargets filename mentions in comments and prose", () => {
+	const converted = retargetTSFilenames(
+		"// generates the entries around src/App.tsx\nSee `vite.config.ts` and `src/routes/users/[id].tsx`. Type declarations stay in `global.d.ts`.",
+	);
+
+	expect(converted).toContain("src/App.jsx");
+	expect(converted).toContain("`vite.config.js`");
+	expect(converted).toContain("[id].jsx");
+	// `.d.ts` files are deleted by the conversion, not renamed
+	expect(converted).toContain("global.d.ts");
+});


### PR DESCRIPTION
## Summary
- Found during #73's verification: scaffolding the Solid 2.0 `basic` template with `--js` produced `extensions: ['.jsx', '.jsx']` in the converted `vite.config.js`. The TS template lists `extensions: ['.jsx', '.tsx']`, and the blanket `.tsx` → `.jsx` retarget regex added in #82 rewrites the second entry into a duplicate of the first.
- Extracted the retarget into a `retargetTSFilenames` helper that dedupes the `extensions` array after the rewrite — the converted config now reads `extensions: ['.jsx']`.
- Also retargets `.ts`/`.tsx` filename mentions in the config's comments and the template README (e.g. `src/App.tsx` → `src/App.jsx`, `` `vite.config.ts` `` → `` `vite.config.js` ``), since every such file is renamed by the conversion. `.d.ts` mentions are excluded — those files are deleted, not transpiled. `.tsx` mentions inside transpiled `src/` sources (JSX text/comments in the route files) are intentionally left as is; rewriting sucrase output in the shared conversion path is out of scope for this fix.
- No changeset: like #83, this only touches unreleased code already covered by the pending `solid-v2-templates` changeset for 0.9.0.

## Test plan
- [x] Root `pnpm test` — 18/18 passing (16 existing + 2 new unit tests for the retarget against the `solid-v2-basic` fixture)
- [x] Re-scaffolded `solid-v2` basic with JS conversion from the local build: config is `extensions: ['.jsx']`, no stale `.tsx` in config/README
- [x] `npm run dev` on the converted app: `/` and `/users` serve 200, and `/src/routes/index.jsx?pick=default&pick=route` compiles through the Solid transform (the `extensions` option's purpose)

Made with [Cursor](https://cursor.com)