### PR TITLE
chore: bump TEMPLATES_REF to templates main (4f54cb7) for browser-mode cleanup

### DIFF
--- a/packages/create/src/utils/download.ts
+++ b/packages/create/src/utils/download.ts
@@ -9,7 +9,7 @@ export const TEMPLATES_REPO = { owner: "solidjs", name: "templates" } as const;
  * later reorganizations of the templates repo. `undefined` means live HEAD of the
  * default branch, which is the historical behavior.
  */
-export const TEMPLATES_REF: string | undefined = "b3d888d309c7173feee2b4cb3ddba8e788af559b";
+export const TEMPLATES_REF: string | undefined = "4f54cb7e3362037c43cece30bb7f228becfddcee";
 
 /** `SOLID_CLI_TEMPLATES_REF` overrides the baked ref, for testing against branches/forks */
 export const templatesRef = () => process.env.SOLID_CLI_TEMPLATES_REF || TEMPLATES_REF;


### PR DESCRIPTION
## Summary
- Bumps the baked templates ref from b3d888d to solidjs/templates@4f54cb7e3362037c43cece30bb7f228becfddcee, picking up the removal of the `environment: 'node'` workaround in `solid-v2/with-vitest-browser-mode` — vite-plugin-solid 3.0.0-next.26 (pinned by templates fb4c013) now gates its jsdom default on `browser.enabled`, so the vitest startup probe that forced the override no longer fires.
- Same shape as the previous ref bump (048ca92): one-line constant change in `packages/create/src/utils/download.ts`, no changeset needed (unreleased code covered by the existing `solid-v2-templates` changeset).

## Test plan
- [x] Templates commit verified on a fresh install: `pnpm install && pnpm test` exits 0, test passes in real Chromium, no jsdom probe error
- [x] Root `pnpm test` — 16/16 passing against live GitHub with the new ref

Made with [Cursor](https://cursor.com)