### PR TITLE
fix: label Solid 2.0 as RC

### DIFF
--- a/.changeset/solid-v2-templates.md
+++ b/.changeset/solid-v2-templates.md
@@ -5,7 +5,7 @@
 
 Solid 2.0 template support
 
-- New "Solid 2.0" top-level project type scaffolding the `solid-v2/*` templates from solidjs/templates (basic, bare, fullstack, fullstack-tanstack, with-\*). Listed first but not preselected while Solid 2.0 core is in beta; existing flags (`-s`, `-v`, `-l`, `--v2`) keep their meaning, plus new `--solid` and `--ssr` flags.
+- New "Solid 2.0" top-level project type scaffolding the `solid-v2/*` templates from solidjs/templates (basic, bare, fullstack, fullstack-tanstack, with-\*). Listed first but not preselected while Solid 2.0 core is a release candidate; existing flags (`-s`, `-v`, `-l`, `--v2`) keep their meaning, plus new `--solid` and `--ssr` flags.
 - Optional streaming SSR on templates that support it (currently `basic`): a scaffold-time flip that sets `ssr: true` in `vite.config.ts`, adds the generic production `server.js`, and points the `start` script at it. Defaults to No.
 - JavaScript variants of the Solid 2.0 templates via the existing sucrase TS→JS conversion (no `index.html` rewrite; `.ts`/`.tsx` references inside `vite.config` are retargeted, `.d.ts` files dropped, minimal `jsconfig.json`).
 - Template lists, subdir paths and per-template flags are now read from a `templates.json` manifest at the templates repo HEAD (2s timeout), with silent fallback to the baked-in lists — so new templates and future repo reorganizations no longer require a CLI release.

--- a/packages/create/src/index.ts
+++ b/packages/create/src/index.ts
@@ -14,7 +14,7 @@ import { readFile, writeFile } from "node:fs/promises";
 export { createVanilla, createStart, createLibrary, createSolidV2 };
 
 const PROJECT_TYPE_LABELS: Record<ProjectType, string> = {
-	solid: "Solid 2.0 (Beta)",
+	solid: "Solid 2.0 (RC)",
 	start: "SolidStart (Solid 1.x)",
 	vanilla: "SolidJS + Vite (Solid 1.x)",
 	library: "Library",
@@ -132,7 +132,7 @@ export const createSolid = (version: string) =>
 			projectType ??= await cancelable(
 				p.select({
 					message: "What type of project would you like to create?",
-					// Solid 2.0 is listed first but not preselected while core is in beta
+					// Solid 2.0 is listed first but not preselected while core is a release candidate
 					initialValue: "start",
 					options: PROJECT_TYPES.map((t) => ({
 						value: t,

--- a/packages/create/src/utils/constants.ts
+++ b/packages/create/src/utils/constants.ts
@@ -134,7 +134,7 @@ export const LIBRARY_TEMPLATES = ["solid-lib-starter"] as const satisfies string
 export type LibraryTemplate = (typeof LIBRARY_TEMPLATES)[number];
 
 // "solid" (Solid 2.0) is listed first, but "start" remains the preselected
-// default while Solid 2.0 core is in beta
+// default while Solid 2.0 core is a release candidate
 export const PROJECT_TYPES = ["solid", "start", "vanilla", "library"] as const satisfies string[];
 export type ProjectType = (typeof PROJECT_TYPES)[number];
 


### PR DESCRIPTION
## Summary
- update the project picker from `Solid 2.0 (Beta)` to `Solid 2.0 (RC)`
- align comments and the pending release note with Solid 2.0's release-candidate status

## Verification
- `pnpm --filter @solid-cli/create build`
- `pnpm exec vitest run packages/create/tests`
- `pnpm exec prettier --check packages/create/src/index.ts packages/create/src/utils/constants.ts .changeset/solid-v2-templates.md`